### PR TITLE
Remove OnDestroy dependency

### DIFF
--- a/BiggerLobby.csproj
+++ b/BiggerLobby.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>BiggerLobby</AssemblyName>
     <Description>Increase the max players to 50 in Lethal Company</Description>
-    <Version>2.2.7</Version>
+    <Version>2.3.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);Harmony003</NoWarn>

--- a/BiggerLobby.csproj
+++ b/BiggerLobby.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>BiggerLobby</AssemblyName>
     <Description>Increase the max players to 50 in Lethal Company</Description>
-    <Version>2.3.1</Version>
+    <Version>2.4.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);Harmony003</NoWarn>

--- a/BiggerLobby.csproj
+++ b/BiggerLobby.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>BiggerLobby</AssemblyName>
     <Description>Increase the max players to 50 in Lethal Company</Description>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);Harmony003</NoWarn>

--- a/Patches/ListSizeTranspilers.cs
+++ b/Patches/ListSizeTranspilers.cs
@@ -13,17 +13,25 @@ namespace BiggerLobby.Patches
     [HarmonyPatch]
     public class ListSizeTranspilers
     {
+        private static MethodInfo _playerCountMethod = AccessTools.Method(typeof(Plugin), "GetPlayerCount");
+        private static MethodInfo _playerCountMinusOneMethod = AccessTools.Method(typeof(Plugin), "GetPlayerCountMinusOne");
+        /*private static List<CodeInstruction> _playerCountInstructions = new List<CodeInstruction>()
+        {
+            new CodeInstruction(OpCodes.Call, _playerCountMethod)
+        };*/
+
         private static void CheckAndReplace(List<CodeInstruction> codes, int index)
         {
             if (codes[index].opcode == OpCodes.Ldc_I4_4)
             {
                 Debug.Log("ok gunna do it");
-                Debug.Log((typeof(Plugin).GetField("MaxPlayers")));
-                codes[index].opcode = OpCodes.Ldsfld;
-                codes[index].operand = (typeof(Plugin).GetField("MaxPlayers"));
+                // Debug.Log((typeof(Plugin).GetField("MaxPlayers")));
+                codes[index].opcode = OpCodes.Call;
+                codes[index].operand = _playerCountMethod;
                 Debug.Log("ok gunna did it");
             }
         }
+
         [HarmonyPatch(typeof(HUDManager), "SyncAllPlayerLevelsServerRpc")]
         [HarmonyPatch(typeof(DressGirlAI), "ChoosePlayerToHaunt")]
         [HarmonyPatch(typeof(CrawlerAI), "Start")]
@@ -91,8 +99,8 @@ namespace BiggerLobby.Patches
             {
                 if (codes[i].opcode == OpCodes.Ldc_I4_3)
                 {
-                    codes[i].opcode = OpCodes.Ldc_I4_S;
-                    codes[i].operand = 39;//lmfao
+                    codes[i].opcode = OpCodes.Call;
+                    codes[i].operand = _playerCountMinusOneMethod; //lmfao
                     Debug.Log("Kick Fix Applied");
                     break;
                 }
@@ -110,8 +118,8 @@ namespace BiggerLobby.Patches
             {
                 if (codes[i].opcode == OpCodes.Ldc_I4_4)
                 {
-                    codes[i].opcode = OpCodes.Ldc_I4_S;
-                    codes[i].operand = Plugin.MaxPlayers;
+                    codes[i].opcode = OpCodes.Call;
+                    codes[i].operand = _playerCountMethod;
                 }
             }
             return codes.AsEnumerable();

--- a/Patches/NonGamePatches.cs
+++ b/Patches/NonGamePatches.cs
@@ -23,6 +23,8 @@ namespace BiggerLobby.Patches
     [HarmonyPatch]
     public class NonGamePatches
     {
+        private static PropertyInfo _playbackVolumeProperty = typeof(Dissonance.Audio.Playback.VoicePlayback).GetInterface("IVoicePlaybackInternal").GetProperty("PlaybackVolume");
+
         [HarmonyPatch(typeof(StartOfRound), "UpdatePlayerVoiceEffects")]
         [HarmonyPrefix]
         public static void UpdatePlayerVoiceEffects(StartOfRound __instance)
@@ -64,7 +66,7 @@ namespace BiggerLobby.Patches
                         playerControllerB2.currentVoiceChatIngameSettings.set2D = true;
                         if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
                         {
-                           (typeof(Dissonance.Audio.Playback.VoicePlayback).GetProperty("Dissonance.Audio.Playback.IVoicePlaybackInternal.PlaybackVolume", BindingFlags.NonPublic | BindingFlags.Instance)).SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent,(SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                            _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
                         }
                     }
                     else
@@ -74,7 +76,7 @@ namespace BiggerLobby.Patches
                         //playerControllerB2.voicePlayerState.Volume = 0f;
                         if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
                         {
-                            (typeof(Dissonance.Audio.Playback.VoicePlayback).GetProperty("PlaybackVolume", BindingFlags.NonPublic | BindingFlags.Instance)).SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, 0);
+                            _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, 0);
                         }
                     }
                     continue;
@@ -120,11 +122,10 @@ namespace BiggerLobby.Patches
                 }
                 else
                 {*/
-                    if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
-                    {
-                      (typeof(Dissonance.Audio.Playback.VoicePlayback).GetProperty("PlaybackVolume", BindingFlags.NonPublic | BindingFlags.Instance)).SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2*Plugin._LoudnessMultiplier.Value));
-                    }
-                //}
+                if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
+                {
+                    _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                }
             }
         }
         [HarmonyPatch(typeof(StartOfRound), "Awake")]

--- a/Patches/NonGamePatches.cs
+++ b/Patches/NonGamePatches.cs
@@ -66,7 +66,7 @@ namespace BiggerLobby.Patches
                         playerControllerB2.currentVoiceChatIngameSettings.set2D = true;
                         if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
                         {
-                            _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                            _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, Mathf.Clamp((SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value), 0f, 1f));
                         }
                     }
                     else
@@ -124,7 +124,7 @@ namespace BiggerLobby.Patches
                 {*/
                 if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
                 {
-                    _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                    _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, Mathf.Clamp((SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value)), 0f, 1f);
                 }
             }
         }
@@ -158,7 +158,7 @@ namespace BiggerLobby.Patches
                 //Debug.Log(__instance.playerVoiceVolumes[j].ToString() + $"PlayerVolume{j}"); dont do this shit its annoying 
                 //__instance.diageticMixer.SetFloat($"PlayerVolume{j}", 16f * __instance.playerVoiceVolumes[j]);
                 if (StartOfRound.Instance.allPlayerScripts[j].voicePlayerState != null) {
-                    (typeof(Dissonance.Audio.Playback.VoicePlayback).GetProperty("Dissonance.Audio.Playback.IVoicePlaybackInternal.PlaybackVolume", BindingFlags.NonPublic | BindingFlags.Instance)).SetValue(StartOfRound.Instance.allPlayerScripts[j].currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[j] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                    (typeof(Dissonance.Audio.Playback.VoicePlayback).GetProperty("Dissonance.Audio.Playback.IVoicePlaybackInternal.PlaybackVolume", BindingFlags.NonPublic | BindingFlags.Instance)).SetValue(StartOfRound.Instance.allPlayerScripts[j].currentVoiceChatIngameSettings._playbackComponent, Mathf.Clamp((SoundManager.Instance.playerVoiceVolumes[j] + 1) * (2 * Plugin._LoudnessMultiplier.Value)), 0f, 1f);
                 }
                 if (Mathf.Abs(__instance.playerVoicePitches[j] - __instance.playerVoicePitchTargets[j]) > 0.025f)
                 {

--- a/Patches/NonGamePatches.cs
+++ b/Patches/NonGamePatches.cs
@@ -261,6 +261,7 @@ namespace BiggerLobby.Patches
             Debug.Log(newnumber);
             Lobby lobby = GameNetworkManager.Instance.currentLobby ?? new Lobby();
             lobby.SetData("MaxPlayers", newnumber.ToString());
+            Debug.Log("SETTING MAX PLAYERS===");
             Plugin.MaxPlayers = newnumber;
             Debug.Log("SetMax");
             Debug.Log(newnumber);
@@ -417,9 +418,9 @@ namespace BiggerLobby.Patches
                         response.Reason = "You cannot rejoin after being kicked.";
                         flag = false;
                     }
-                    else if (!(@string.Contains("BiggerLobbyVersion2.2.7")))
+                    else if (!(@string.Contains("BiggerLobbyVersion2.4.0")))
                     {
-                        response.Reason = "You need to have <color=#008282>BiggerLobby V2.2.7</color> to join this server!";
+                        response.Reason = "You need to have <color=#008282>BiggerLobby V2.4.0</color> to join this server!";
                         flag = false;
                     }
                 }
@@ -458,11 +459,11 @@ namespace BiggerLobby.Patches
             Debug.Log("Game version: " + __instance.gameVersionNum);
             if (__instance.disableSteam)
             {
-                NetworkManager.Singleton.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(__instance.gameVersionNum.ToString() + "," + "BiggerLobbyVersion2.2.7");//this nonsense ass string exists to tell the server if youre running biggerlobby for some reason. Also she fortnite on my burger till I battle pass
+                NetworkManager.Singleton.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(__instance.gameVersionNum.ToString() + "," + "BiggerLobbyVersion2.4.0");//this nonsense ass string exists to tell the server if youre running biggerlobby for some reason. Also she fortnite on my burger till I battle pass
             }
             else
             {
-                NetworkManager.Singleton.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(__instance.gameVersionNum + "," + (ulong)SteamClient.SteamId + "," + "BiggerLobbyVersion2.2.7");
+                NetworkManager.Singleton.NetworkConfig.ConnectionData = Encoding.ASCII.GetBytes(__instance.gameVersionNum + "," + (ulong)SteamClient.SteamId + "," + "BiggerLobbyVersion2.4.0");
             }
             return (false);
         }
@@ -503,6 +504,7 @@ namespace BiggerLobby.Patches
             Debug.Log(newnumber);
             Debug.Log(lobby.GetData("MaxPlayers"));
             Debug.Log(newnumber);
+            Debug.Log("SETTING MAX PLAYERS===");
             Plugin.MaxPlayers = newnumber;
             // Lobby member count check is skipped here, see original method
             __result = true;

--- a/Patches/PlayerObjects.cs
+++ b/Patches/PlayerObjects.cs
@@ -314,14 +314,9 @@ namespace BiggerLobby.Patches
 
         public static bool SyncShipUnlockablesClientRpc(StartOfRound __instance, int[] playerSuitIDs, bool shipLightsOn, UnityEngine.Vector3[] placeableObjectPositions, UnityEngine.Vector3[] placeableObjectRotations, int[] placeableObjects, int[] storedItems, int[] scrapValues, int[] itemSaveData)
         {
-            /*Debug.Log("AEAEAEAEEAEAE");
-            Debug.Log(playerSuitIDs.Length);
+            Debug.Log("INITIAL ARRAY LENGTHS");
             Debug.Log(__instance.allPlayerScripts.Length);
-            for (int l = 0; l < __instance.allPlayerScripts.Length; l++)
-            {
-                Debug.Log(playerSuitIDs[l]);
-            }
-            Debug.Log("OAKY!");*/
+            Debug.Log(playerSuitIDs.Length);
             return true;
         }
 

--- a/Patches/PlayerObjects.cs
+++ b/Patches/PlayerObjects.cs
@@ -314,16 +314,17 @@ namespace BiggerLobby.Patches
 
         public static bool SyncShipUnlockablesClientRpc(StartOfRound __instance, int[] playerSuitIDs, bool shipLightsOn, UnityEngine.Vector3[] placeableObjectPositions, UnityEngine.Vector3[] placeableObjectRotations, int[] placeableObjects, int[] storedItems, int[] scrapValues, int[] itemSaveData)
         {
-            Debug.Log("AEAEAEAEEAEAE");
+            /*Debug.Log("AEAEAEAEEAEAE");
             Debug.Log(playerSuitIDs.Length);
             Debug.Log(__instance.allPlayerScripts.Length);
             for (int l = 0; l < __instance.allPlayerScripts.Length; l++)
             {
                 Debug.Log(playerSuitIDs[l]);
             }
-            Debug.Log("OAKY!");
-            return (true);
+            Debug.Log("OAKY!");*/
+            return true;
         }
+
         [HarmonyPatch(typeof(ManualCameraRenderer), "Awake")]
         [HarmonyPrefix]
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -73,5 +73,17 @@ namespace BiggerLobby
             }
             
         }
+
+        public static int GetPlayerCount()
+        {
+            // Debug.Log("GETTING MAX PLAyERS");
+            return MaxPlayers;
+        }
+
+        public static int GetPlayerCountMinusOne()
+        {
+            // Debug.Log("Getting max players -1");
+            return MaxPlayers - 1;
+        }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -24,6 +24,7 @@ namespace BiggerLobby
         public static Harmony _harmony;
         public static Harmony _harmony2;
         public static ConfigEntry<int>? _LoudnessMultiplier;
+        public static bool Initialized = false;
 
         public static IDictionary<uint, NetworkObject> CustomNetObjects = new Dictionary<uint, NetworkObject> { };
         private void Awake()
@@ -43,6 +44,25 @@ namespace BiggerLobby
             LC_API.BundleAPI.BundleLoader.OnLoadedAssets += OnLoaded;
         }
 
+        private void Start()
+        {
+            Initialize();
+        }
+
+        // Legacy behaviour for if BepInEx.cfg's "HideManagerGameObject" is set to false
+        private void OnDestroy()
+        {
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            if (!Initialized)
+            {
+                Initialized = true;
+                LC_API.ServerAPI.ModdedServer.SetServerModdedOnly();
+            }
+        }
 
         private void OnLoaded()
         {
@@ -52,10 +72,6 @@ namespace BiggerLobby
                 return;
             }
             
-        }
-        private void OnDestroy()
-        {
-            LC_API.ServerAPI.ModdedServer.SetServerModdedOnly();
         }
     }
 }


### PR DESCRIPTION
Right now, this plugin will only properly call `LC_API.ServerAPI.ModdedServer.SetServerModdedOnly();` if BepInEx.cfg's "HideManagerGameObject" is set to false.

Ideally it should support either config value so the value can eventually be set to "true" by default, and allow modders to use Update()/other unity methods directly in plugins